### PR TITLE
TASK: Use FileType API if defined

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metedata.php
+++ b/Configuration/TCA/Overrides/sys_file_metedata.php
@@ -20,6 +20,6 @@
  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
      'sys_file_metadata',
      'start',
-     TYPO3\CMS\Core\Resource\FileType::VIDEO->value,
+     defined('TYPO3\CMS\Core\Resource\FileType::VIDEO') ? TYPO3\CMS\Core\Resource\FileType::VIDEO->value : TYPO3\CMS\Core\Resource\AbstractFile::FILETYPE_VIDEO,
      'after:duration'
  );


### PR DESCRIPTION
To keep the composer.json promised support, the value of the VIDEO format must be retrieved from AbstractFile if the FileType API is not present

Fixes https://github.com/b13/twentythree/issues/8